### PR TITLE
Fix incorrect column name in "select all" example

### DIFF
--- a/src/components/datatable/readme.md
+++ b/src/components/datatable/readme.md
@@ -253,7 +253,7 @@ To override this all we have to do is define a template in our datatable and tel
 
     <!-- Define the rest of our columns here -->
 
-    <template slot="sel" scope="cell">
+    <template slot="select-all" scope="cell">
         <div class="checkable-column">
             <checkbox :id="cell.row.id" :val="cell.row" v-model="customers.selected"></checkbox>
         </div>


### PR DESCRIPTION
Just a minor text fix in the "select all" datatable example so the slot in the template matches the column id.